### PR TITLE
Extended newline replacement to handle Windows-style CRLF newlines

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -117,7 +117,7 @@ i18nStringsFiles.prototype.compile = (data) ->
     msgstr = msgstr.replace(/"/g, "\\\"")
     # escape new lines in msgid, msgstr
     msgid = msgid.replace(/\n/g, "\\n")
-    msgstr = msgstr.replace(/\n/g, "\\n")
+    msgstr = msgstr.replace(/\r?\n/g, "\\n")
     # add line to output
     output = output + "\"" + msgid + "\" = \"" + msgstr + "\";\n"
   # return output string

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@
       msgid = msgid.replace(/"/g, "\\\"");
       msgstr = msgstr.replace(/"/g, "\\\"");
       msgid = msgid.replace(/\n/g, "\\n");
-      msgstr = msgstr.replace(/\n/g, "\\n");
+      msgstr = msgstr.replace(/\r?\n/g, "\\n");
       output = output + "\"" + msgid + "\" = \"" + msgstr + "\";\n";
     }
     return output;

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -69,3 +69,17 @@ describe 'Async: Read, write, read (no encoding param)', ->
           checkValues(data)
           fs.unlinkSync(fileTemp)
           done()
+
+describe 'Compilation', ->
+  it 'shall replace windows-style CRLF newlines with LF(mac/unix) newlines', (done) ->
+    # Given: a dictionary containing a value string with CRLF newlines
+    crlfDict = { aKey: 'Test\r\nNew\r\nLines' };
+
+    # When: the dictionary is compiled to strings file format
+    stringsFileContent = i18nStringsFiles.compile(crlfDict);
+
+    # Then: the resulting content shall match the content crated for LF-only source
+    lfDict = { aKey: 'Test\nNew\nLines' };
+    stringsFileContent.should.equal(i18nStringsFiles.compile(lfDict));
+
+    done()

--- a/test/test.js
+++ b/test/test.js
@@ -93,4 +93,19 @@
     });
   });
 
+  describe('Compilation', function() {
+    return it('shall replace windows-style CRLF newlines with LF(mac/unix) newlines', function(done) {
+      var crlfDict, lfDict, stringsFileContent;
+      crlfDict = {
+        aKey: 'Test\r\nNew\r\nLines'
+      };
+      stringsFileContent = i18nStringsFiles.compile(crlfDict);
+      lfDict = {
+        aKey: 'Test\nNew\nLines'
+      };
+      stringsFileContent.should.equal(i18nStringsFiles.compile(lfDict));
+      return done();
+    });
+  });
+
 }).call(this);


### PR DESCRIPTION
Data from external sources (files, web services) often contain windows-style CRLF newlines that are not valid in Xcode. When only replacing '\n' with escaped newlines, a CR ('\r') character will remain and make the file invalid.
This pull request fixes this issue by extending the replacement regex to also match '\r\n' (CRLF) newlines. It also includes a unit test for this issue.
