### PR TITLE
Update iconv version in package.json, so npm install works on Node v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "git://github.com/justinklemm/i18n-strings-files.git"
   },
   "dependencies": {
-    "iconv": "2.3.0"
+    "iconv": "^2.3.0"
   },
   "devDependencies": {
     "mocha": "2.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-strings-files",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "./index.js",
   "description": "Process .strings files used for localization in iOS/OSX development",
   "homepage": "https://github.com/justinklemm/i18n-strings-files",
@@ -13,7 +13,7 @@
     "url": "git://github.com/justinklemm/i18n-strings-files.git"
   },
   "dependencies": {
-    "iconv": "2.2.0"
+    "iconv": "2.3.0"
   },
   "devDependencies": {
     "mocha": "2.4.5",


### PR DESCRIPTION
Currently, `npm install i18n-string-files` fails on node v10. Newer version of `iconv` package need to be used on node v10.